### PR TITLE
Update Start.sh script, moved build operation to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+git pull
+./gradlew clean build
+./start.sh

--- a/start.sh
+++ b/start.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 
 while true
 do
-	git pull
-	./gradlew clean build
-	java -Xmx512M -jar build/libs/*.jar
-	echo "Press Ctrl+C to stop"
+	# The ParNewGC only has marginally better YoungGen collection time at the expense of MT overhead.
+	# -XX:+UseParNewGC -XX:ConcGCThreads=4 -XX:ParallelGCThreads=4
+	java -server -Xmx180M -XX:NewSize=80M -XX:+UseSerialGC -jar build/libs/*.jar
+	echo "Restarting. Press Ctrl+C to stop"
 	sleep 3
 done


### PR DESCRIPTION
The GC settings were eye-balled, low effort, with the hope that the proxy doesn't leak memory.

Explicit `-server` because we expect the proxy to run for a long time, SerialGC because we don't need n-Threads on a multicore machine for such a tiny application.

As explained, ParNewGC only had miniscule improvement in GC time, N=2 had not noticable difference, N=4 cut down time by ~2-4ms, but YoungGen collections are rare enough that we might as well not care. That option is commented, anyone can restore it.

Previously all default JVM settings were to be used. And whoever's running OpenJ9 can probably figure stuff out on their own for now? I'm pretty sure `UseSerialGC` is HotSpot-only.